### PR TITLE
fix(ingress): Update ingress ext traffic policy from local to cluster

### DIFF
--- a/kubernetes/tools/magician/template/std/config/nginx.yaml
+++ b/kubernetes/tools/magician/template/std/config/nginx.yaml
@@ -359,7 +359,7 @@ metadata:
   name: ingress-nginx-controller
   namespace: ingress-nginx
 spec:
-  externalTrafficPolicy: Local
+  externalTrafficPolicy: Cluster
   ipFamilies:
   - IPv4
   ipFamilyPolicy: SingleStack


### PR DESCRIPTION
When using the externalTrafficPolicy as "Local", nodes that do not have one of the backend Pods appear as unhealthy/No Traffic to the TCP/UDP load balancer. Traffic will only be sent to one of the remaining healthy cluster nodes which has the Pod. It risks potentially imbalanced traffic spreading.

If your node’s status is showing as “No Traffic”, the Kubernetes service’s externaltrafficpolicy setting could be rejecting the load balancer’s health checks. This setting describes how nodes should respond to health checks from an external load balancer and can make nodes appear with the “No Traffic” status if not set appropriately.

Most likely, your nodes are configured to reject health checks if they do not have a pod for that service running locally. If a node rejects a health check for a service, the load balancer shows the node status as “No Traffic” in the DigitalOcean Control Panel.

The service’s externaltrafficpolicy setting affects how nodes respond to these health checks when set with the following values:

- Local
- Cluster

To update this setting for a service, use the following command substituting <traffic-policy-value> for Local or Cluster:

```
kubectl patch svc <your-service> -p '{"spec":{"externalTrafficPolicy":"<traffic-policy-value>"}}'
```

Please refer below document for more detailed
https://docs.digitalocean.com/support/why-do-my-load-balancers-kubernetes-nodes-have-the-no-traffic-status/